### PR TITLE
Adding gifv/web/mp4 embedding for imgur.

### DIFF
--- a/handlebars_helpers.js
+++ b/handlebars_helpers.js
@@ -56,9 +56,19 @@ Handlebars.registerHelper("picHelper", function (data)
     {
         return prefix + ".jpg" + suffix;
     }
-    else if (data.domain == "i.imgur.com")
+    else if (data.domain == "i.imgur.com" && !isImgurVid(data.url))
     {
         return prefix + suffix;
+    }
+    else if (data.domain == "i.imgur.com" && isImgurVid(data.url))
+    {
+        var nakedUrl = data.url.split(data.url.match(/\.([A-Za-z0-9]+)$/g)[0])[0];
+        var embededVideo = "<video autoplay loop muted preload id='storyimage'>";
+		embededVideo += "<source src='" + nakedUrl + ".webm' type='video/webm'>";
+        embededVideo += "<source src='" + nakedUrl + ".mp4' type='video/mp4'>";
+		embededVideo += "</video>";
+
+		return embededVideo;
     }
     else if (data.domain.indexOf("tumblr") != -1)
     {

--- a/main.js
+++ b/main.js
@@ -368,3 +368,11 @@ function getYoutubeId(url)  // Returns youtube data-id
 	}
 }
 
+function isImgurVid(url) // Returns true if url is .gifv, .webm, or .mp4
+{
+    var exts = [".gifv", ".webm", ".mp4"];
+    for (var i in exts) {
+        if(url.indexOf(exts[i]) == url.length - exts[i].length) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
This fixes #1 by allowing imgur .gifv, .webm, and .mp4 files to be embedded. I tried to keep syntax style consistent with the original style.

Haven't been able to give it a full testing yet, but this should work just fine.
