### PR TITLE
Changed some escaping methods of titles

### DIFF
--- a/handlebars_helpers.js
+++ b/handlebars_helpers.js
@@ -19,7 +19,7 @@ Handlebars.registerHelper("subHelper", function (data)
 
 Handlebars.registerHelper("htmlHelper", function (data)
 {
-   return htmlDecode(data);
+   return new Handlebars.SafeString(htmlDecode(data));
 });
 
 Handlebars.registerHelper("ptsHelper", function (ups)

--- a/index.php
+++ b/index.php
@@ -181,7 +181,7 @@
 
 	<div data-id="{{id}}" data-sub="{{subreddit}}" class="row entries">
 		<div class="col-xs-3 col-md-2 col-lg-1 text-center">{{score}}</span></div>
-		<div class="col-xs-6 col-md-8 col-lg-10 title">{{{htmlHelper title}}} <small>{{{nsfwHelper over_18}}} {{{stickyHelper stickied}}} {{subHelper this}}</small> </div>
+		<div class="col-xs-6 col-md-8 col-lg-10 title">{{{title}}} <small>{{{nsfwHelper over_18}}} {{{stickyHelper stickied}}} {{subHelper this}}</small> </div>
 		<div class="col-xs-3 col-md-2 col-lg-1 text-center">{{num_comments}}<br /></span></div>
 	</div>
 
@@ -190,7 +190,7 @@
 <script id="story-template" type="text/x-handlebars-template">
 	<div class="row">
 		<div class='story-title col-xs-12'>
-			<strong>{{{htmlHelper title}}}</strong><br /><small>{{{authorHelper author}}} - {{timeHelper created_utc}}</small>
+			<strong>{{{title}}}</strong><br /><small>{{{authorHelper author}}} - {{timeHelper created_utc}}</small>
  	</div>
 </div>
 <div class="row">


### PR DESCRIPTION
I'm not 100 percent on comments and self post text. But titles are properly escaped now. 
