### PR TITLE
Removed resize() from js, can be achieved with css

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,6 @@ $(function()
 {
 	init();
 	hashLocation();
-	resize();
 	setTitle();
 	getPopularSubs();
 	buildHandlebars();
@@ -76,13 +75,6 @@ function buildHandlebars()
 	var raw_template = $('#story-template').html();
 	storyTemplate = Handlebars.compile(raw_template);
 	storyPlaceHolder = $("#story");
-}
-
-function resize()	// Resize containers when window changes
-{
-	ht = $(window).height();
-	$("#leftcolumn").css("height", ht-91 + "px");
-	$("#rightcolumn").css("height", ht-91 + "px");
 }
 
 function setTitle() // Set page title if cookie exists

--- a/style.css
+++ b/style.css
@@ -27,8 +27,14 @@ blockquote
 	background-color: rgba(128, 128, 128, 0.03);
 }
 
+html
+{
+	height: 100%;
+}
+
 body
 {
+	height: 100%;
 	padding-top: 91px;
 }
 
@@ -135,8 +141,14 @@ input[type=checkbox]
 	margin-top:6px;
 }
 
+.container-fixed
+{
+	height: 100%;
+}
+
 #leftcolumn
 {
+	height: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;
 	border-right: 1px solid #eee;
@@ -195,6 +207,7 @@ p
 
 #rightcolumn
 {
+	height: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;
 	padding-right: 0;


### PR DESCRIPTION
By setting the html, body, .container-fixed, #leftcolumn and
# rightcolumn's height to 100%, resize function becomes unneeded.
